### PR TITLE
Handle crashes when camera cannot connect

### DIFF
--- a/vimbaApp/src/ADVimba.cpp
+++ b/vimbaApp/src/ADVimba.cpp
@@ -152,6 +152,11 @@ ADVimba::ADVimba(const char *portName, const char *cameraId,
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
             "%s:%s:  camera connection failed (%d)\n",
             driverName, functionName, status);
+        // Mark camera unreachable
+        this->deviceIsReachable = false;
+        this->disconnect(pasynUserSelf);
+        setIntegerParam(ADStatus, ADStatusDisconnected);
+        setStringParam(ADStatusMessage, "Camera disconnected");
         // Call report() to get a list of available cameras
         report(stdout, 1);
         return;

--- a/vimbaApp/src/VimbaFeature.cpp
+++ b/vimbaApp/src/VimbaFeature.cpp
@@ -21,7 +21,7 @@ VimbaFeature::VimbaFeature(GenICamFeatureSet *set,
 {
     static const char *functionName = "VimbaFeature";
     
-    if (VmbErrorSuccess == mCameraPtr->GetFeatureByName(featureName.c_str(), mFeaturePtr)) {
+    if (mCameraPtr && VmbErrorSuccess == mCameraPtr->GetFeatureByName(featureName.c_str(), mFeaturePtr)) {
         mIsImplemented = true;
         VmbFeatureDataType dataType;
         checkError(mFeaturePtr->GetDataType(dataType), "VimbaFeature", "GetDataType");


### PR DESCRIPTION
I often run multiple cameras on one IOC. In case of one camera unplugged, I would like the other cameras still function. 
This PR adds a check of NULL pointer, which avoids the crash and marks the device unreachable.
