### PR TITLE
Removed ADGenICamSupport.dbd from the ioc's src/Makefile

### DIFF
--- a/iocs/vimbaIOC/vimbaApp/src/Makefile
+++ b/iocs/vimbaIOC/vimbaApp/src/Makefile
@@ -13,7 +13,6 @@ endif
 
 # <name>.dbd will be created from <name>Include.dbd
 DBD += $(PROD_NAME).dbd
-$(PROD_NAME)_DBD += ADGenICamSupport.dbd
 $(PROD_NAME)_DBD += ADVimbaSupport.dbd
 
 # <name>_registerRecordDeviceDriver.cpp will be created from <name>.dbd


### PR DESCRIPTION
The file is no longer needed and it is not mentioned anywhere in the module's source code.